### PR TITLE
Get rid of Text dumper by adapting JSON values.

### DIFF
--- a/django/contrib/postgres/fields/citext.py
+++ b/django/contrib/postgres/fields/citext.py
@@ -1,5 +1,6 @@
 import warnings
 
+from django.db.backends.postgresql.base import CIStr
 from django.db.models import CharField, EmailField, TextField
 from django.test.utils import ignore_warnings
 from django.utils.deprecation import RemovedInDjango51Warning
@@ -22,6 +23,11 @@ class CIText:
 
     def db_type(self, connection):
         return "citext"
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if value is None or hasattr(value, "as_sql"):
+            return value
+        return CIStr(value)
 
 
 class CICharField(CIText, CharField):

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -48,11 +48,15 @@ if is_psycopg3:
     from psycopg.pq import Format
     from psycopg.types.datetime import TimestamptzLoader
     from psycopg.types.range import Range, RangeDumper
-    from psycopg.types.string import TextLoader
+    from psycopg.types.string import StrDumper, StrDumperUnknown, TextLoader
 
     TIMESTAMPTZ_OID = psycopg.adapters.types["timestamptz"].oid
     TSRANGE_OID = psycopg.postgres.types["tsrange"].oid
     TSTZRANGE_OID = psycopg.postgres.types["tstzrange"].oid
+
+    # RemovedInDjango51Warning.
+    class CIStr(str):
+        pass
 else:
     import psycopg2.extensions
     import psycopg2.extras
@@ -69,6 +73,7 @@ else:
         psycopg2.extensions.UNICODE,
     )
     psycopg2.extensions.register_type(INETARRAY)
+    CIStr = str
 
 # Some of these import psycopg, so import them after checking if it's installed.
 from .client import DatabaseClient  # NOQA isort:skip
@@ -102,6 +107,9 @@ def get_adapters_template(use_tz, timezone):
     # Dump strings using the text oid, where the default unknown oid
     # doesn't work well (e.g. in variadic functions)
     ctx.register_dumper(str, StrDumper)
+
+    # RemovedInDjango51Warning.
+    ctx.register_dumper(CIStr, StrDumperUnknown)
 
     return ctx
 


### PR DESCRIPTION
This still needs to be broken down into separate commits.

@apollo13 this is still very rough but it seems to pass the suite on SQLite, Pyscopg2 and 3.

I'd like to find time to have the `adapt_json_value` changes merged in `main` first so that'll be one less thing to worry about.

One thing I still want to figure out is a way to have func/lookups that expect JSON arguments and receive a `Value(str)` to not require a `JSONField` output field as that's backward incompatible. The reason why you were hitting these snags is that `Value(str)` resolves its output field to `CharField`, I really think we want to deprecate allowing to pass encoded strings to `Value` and have it magically be handled.

My goal is to make everything I can to make sure we get psycopg3 support in Django 4.2.